### PR TITLE
Fixed readability of checkboxes.

### DIFF
--- a/resources/Monocai.theme.json
+++ b/resources/Monocai.theme.json
@@ -369,13 +369,13 @@
 
       "Checkbox.Background.Default.Dark": "#2d2a2f",
       "Checkbox.Border.Default.Dark": "#727072",
-      "Checkbox.Foreground.Selected.Dark": "#403e42",
+      "Checkbox.Foreground.Selected.Dark": "#fcfcfb",
       "Checkbox.Focus.Wide.Dark": "#403e42",
       "Checkbox.Focus.Thin.Default.Dark": "#fcfcfb",
       "Checkbox.Focus.Thin.Selected.Dark": "#fcfcfb",
       "Checkbox.Background.Disabled.Dark": "#2d2a2f",
       "Checkbox.Border.Disabled.Dark": "#2d2a2f",
-      "Checkbox.Foreground.Disabled.Dark": "#727072"
+      "Checkbox.Foreground.Disabled.Dark": "#fcfcfb"
     }
   }
 }


### PR DESCRIPTION
Checkboxes are not readable with the old settings. Changed them to be white. Result:

![image](https://user-images.githubusercontent.com/1206407/57055991-995b2d00-6c9f-11e9-8784-e486429f478c.png)
