### PR TITLE
Introduced highlight for the current line

### DIFF
--- a/resources/themes/Monocai.xml
+++ b/resources/themes/Monocai.xml
@@ -9,7 +9,7 @@
     <option name="ADDED_LINES_COLOR" value="295622" />
     <option name="ANNOTATIONS_COLOR" value="b2c0c6" />
     <option name="CARET_COLOR" value="bbbbbb" />
-    <option name="CARET_ROW_COLOR" value="" />
+    <option name="CARET_ROW_COLOR" value="727072" />
     <option name="CONSOLE_BACKGROUND_KEY" value="1c1c1c" />
     <option name="FILESTATUS_ADDED" value="629755" />
     <option name="FILESTATUS_DELETED" value="6c6c6c" />


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Improve the user experience make easier for to spot the current line

**What was made to achieve this purpose**
As explained in [Jetbrains documentation](http://www.jetbrains.org/intellij/sdk/docs/reference_guide/ui_themes/themes_extras.html#adding-a-custom-editor-scheme) I change the property `CARET_ROW_COLOR` in the xml to make the current line be highlighted in `#727072`.

![image](https://user-images.githubusercontent.com/5021565/66273801-b814af80-e84d-11e9-9d49-d85f1024e79b.png)
